### PR TITLE
Advanced Options Search

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
             <option value="1">Animals</option>
             <option value="355675">Vertebrates</option>
           </select>
-          <div class="place-search-container">
+          <div class="place-search-container" style="display: none">
             <input
               type="text"
               id="placeNameInput"
@@ -44,7 +44,7 @@
             />
             <div id="placeAutocomplete" class="place-autocomplete"></div>
           </div>
-          <input type="text" id="placeIdInput" style="display: none" />
+          <input type="text" id="placeIdInput" placeholder="Place ID"/>
           <select id="limitSelect" class="limit-select">
             <option value="100">Top 100 Species</option>
             <option value="200">Top 200 Species</option>
@@ -63,7 +63,9 @@
           <input type="checkbox" id="wildCheckbox" class="wild-checkbox" />
           <label for="wildCheckbox">Wild Only</label>
           <input type="checkbox" id="includeAllPlacesCheckbox" class="include-all-places-checkbox" />
-          <label for="includeAllPlacesCheckbox">Include Observations From All Places</label>
+          <label for="includeAllPlacesCheckbox">Include My Observations From All Places</label>
+          <input type="checkbox" id="researchGradeCheckbox" class="research-grade-checkbox" />
+          <label for="researchGradeCheckbox">Research Grade Only</label>
         </div>
         <div class="status-bar" id="statusBar">
           <div class="status-text">

--- a/index.html
+++ b/index.html
@@ -66,6 +66,23 @@
           <label for="includeAllPlacesCheckbox">Include My Observations From All Places</label>
           <input type="checkbox" id="researchGradeCheckbox" class="research-grade-checkbox" />
           <label for="researchGradeCheckbox">Research Grade Only</label>
+          <div class="month-filter-container">
+            <button id="monthDropdownButton" type="button" class="month-dropdown-button">Filter Species Set by Month</button>
+            <div id="monthCheckboxes" class="month-checkboxes" style="display: none;">
+              <label><input type="checkbox" value="1"> January</label>
+              <label><input type="checkbox" value="2"> February</label>
+              <label><input type="checkbox" value="3"> March</label>
+              <label><input type="checkbox" value="4"> April</label>
+              <label><input type="checkbox" value="5"> May</label>
+              <label><input type="checkbox" value="6"> June</label>
+              <label><input type="checkbox" value="7"> July</label>
+              <label><input type="checkbox" value="8"> August</label>
+              <label><input type="checkbox" value="9"> September</label>
+              <label><input type="checkbox" value="10"> October</label>
+              <label><input type="checkbox" value="11"> November</label>
+              <label><input type="checkbox" value="12"> December</label>
+            </div>
+          </div>
         </div>
         <div class="status-bar" id="statusBar">
           <div class="status-text">

--- a/index.html
+++ b/index.html
@@ -32,6 +32,8 @@
             <option value="47115">Mollusks</option>
             <option value="47126">Plants</option>
             <option value="47170">Fungi</option>
+            <option value="1">Animals</option>
+            <option value="355675">Vertebrates</option>
           </select>
           <input type="text" id="placeIdInput" placeholder="Enter place ID" />
           <select id="limitSelect" class="limit-select">
@@ -45,6 +47,14 @@
             placeholder="Enter iNaturalist username"
           />
           <button id="searchButton">Search</button>
+          <button id="advancedOptionsButton" type="button">Advanced Options</button>
+        </div>
+        <div id="advancedOptionsSection" class="advanced-options-section" style="display: none;">
+          <input id="taxonIdOverrideInput" class="taxon-id-override-input" placeholder="Taxon ID"/>
+          <input type="checkbox" id="wildCheckbox" class="wild-checkbox" />
+          <label for="wildCheckbox">Wild Only</label>
+          <input type="checkbox" id="includeAllPlacesCheckbox" class="include-all-places-checkbox" />
+          <label for="includeAllPlacesCheckbox">Include Observations From All Places</label>
         </div>
         <div class="status-bar" id="statusBar">
           <div class="status-text">

--- a/script.js
+++ b/script.js
@@ -16,6 +16,7 @@ document.addEventListener("DOMContentLoaded", function () {
   const taxonIdOverrideInput = document.getElementById("taxonIdOverrideInput");
   const wildCheckbox = document.getElementById("wildCheckbox");
   const includeAllPlacesCheckbox = document.getElementById("includeAllPlacesCheckbox");
+  const researchGradeCheckbox = document.getElementById("researchGradeCheckbox");
 
   // Load saved username, place ID, taxon, and limit preference from localStorage
   const savedUsername = localStorage.getItem("inatUsername");
@@ -137,6 +138,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
   searchButton.addEventListener("click", async () => {
     placeId = placeIdInput.value.trim();
+    console.log("Place ID: " + placeId)
     const username = usernameInput.value.trim();
     let taxonId = taxonSelect.value;
     if (taxonIdOverrideInput && taxonIdOverrideInput.value.trim() !== "") {
@@ -184,6 +186,9 @@ document.addEventListener("DOMContentLoaded", function () {
     if (wildCheckbox && wildCheckbox.checked) {
       url = url.replace('?', '?captive=false&');
     }
+    if (researchGradeCheckbox && researchGradeCheckbox.checked) {
+      url += `&quality_grade=research`;
+    }
     const response = await fetch(url);
     const data = await response.json();
 
@@ -193,6 +198,9 @@ document.addEventListener("DOMContentLoaded", function () {
       let allPlacesUrl = `https://api.inaturalist.org/v1/observations/taxonomy?user_login=${username}${taxonParam}`;
       if (wildCheckbox && wildCheckbox.checked) {
         allPlacesUrl = allPlacesUrl.replace('?', '?captive=false&');
+      }
+      if (researchGradeCheckbox && researchGradeCheckbox.checked) {
+        allPlacesUrl += `&quality_grade=research`;
       }
       const allPlacesResponse = await fetch(allPlacesUrl);
       const allPlacesData = await allPlacesResponse.json();
@@ -208,6 +216,9 @@ document.addEventListener("DOMContentLoaded", function () {
     let url = `https://api.inaturalist.org/v1/observations/species_counts?place_id=${placeId}&per_page=${limit}${taxonParam}`;
     if (wildCheckbox && wildCheckbox.checked) {
       url = url.replace('?', '?captive=false&');
+    }
+    if (researchGradeCheckbox && researchGradeCheckbox.checked) {
+      url += `&quality_grade=research`;
     }
     const response = await fetch(url);
     const data = await response.json();
@@ -226,11 +237,11 @@ document.addEventListener("DOMContentLoaded", function () {
     let observed = 0;
     const total = species.length;
 
-    species.forEach((specimen) => {
+    species.forEach((specimen, index) => {
       const isObserved = userObservations.has(specimen.taxon.id);
       if (isObserved) observed++;
 
-      const card = createSpeciesCard(specimen, isObserved);
+      const card = createSpeciesCard(specimen, isObserved, index);
       speciesGrid.appendChild(card);
     });
 
@@ -238,7 +249,7 @@ document.addEventListener("DOMContentLoaded", function () {
     document.querySelector(".checkbox-container").style.display = "inline-flex";
   }
 
-  function createSpeciesCard(specimen, isObserved) {
+  function createSpeciesCard(specimen, isObserved, index) {
     const card = document.createElement("div");
     card.className = `species-card ${isObserved ? "observed" : ""}`;
     const imageUrl =
@@ -253,7 +264,7 @@ document.addEventListener("DOMContentLoaded", function () {
         <img src="${imageUrl}" alt="${specimen.taxon.name}">
         <h3>${specimen.taxon.preferred_common_name || specimen.taxon.name}</h3>
         <p class="scientific-name">${specimen.taxon.name}</p>
-        <p class="observations">Observations: ${specimen.count}</p>
+        <p class="observations">Observations: ${specimen.count} (#${index + 1})</p>
       </a>
     `;
     return card;

--- a/script.js
+++ b/script.js
@@ -9,6 +9,11 @@ document.addEventListener("DOMContentLoaded", function () {
   const totalCount = document.getElementById("totalCount");
   const progressBar = document.getElementById("progressBar");
   const showMissingCheckbox = document.getElementById("showMissingOnly");
+  const advancedOptionsButton = document.getElementById("advancedOptionsButton");
+  const advancedOptionsSection = document.getElementById("advancedOptionsSection");
+  const taxonIdOverrideInput = document.getElementById("taxonIdOverrideInput");
+  const wildCheckbox = document.getElementById("wildCheckbox");
+  const includeAllPlacesCheckbox = document.getElementById("includeAllPlacesCheckbox");
 
   // Load saved username, place ID, taxon, and limit preference from localStorage
   const savedUsername = localStorage.getItem("inatUsername");
@@ -63,6 +68,14 @@ document.addEventListener("DOMContentLoaded", function () {
     speciesGrid.className = `species-grid`;
     // Save the selected taxon to localStorage
     localStorage.setItem("inatTaxon", taxonSelect.value);
+    // Populate the taxonIdOverrideInput with the selected value, or clear if 'all'
+    if (taxonIdOverrideInput) {
+      if (taxonSelect.value === "all") {
+        taxonIdOverrideInput.value = "";
+      } else {
+        taxonIdOverrideInput.value = taxonSelect.value;
+      }
+    }
   });
 
   // Add event listener for taxon selection
@@ -93,10 +106,31 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   }
 
+  if (advancedOptionsButton && advancedOptionsSection) {
+    advancedOptionsButton.addEventListener("click", function () {
+      if (advancedOptionsSection.style.display === "none") {
+        advancedOptionsSection.style.display = "block";
+      } else {
+        advancedOptionsSection.style.display = "none";
+      }
+    });
+  }
+
+  if (taxonIdOverrideInput) {
+    taxonIdOverrideInput.addEventListener("input", function () {
+      if (taxonSelect) {
+        taxonSelect.value = "all";
+      }
+    });
+  }
+
   searchButton.addEventListener("click", async () => {
     const placeId = placeIdInput.value.trim();
     const username = usernameInput.value.trim();
-    const taxonId = taxonSelect.value;
+    let taxonId = taxonSelect.value;
+    if (taxonIdOverrideInput && taxonIdOverrideInput.value.trim() !== "") {
+      taxonId = taxonIdOverrideInput.value.trim();
+    }
     showMissingCheckbox.checked = false;
 
     if (!placeId || !username) {
@@ -131,20 +165,36 @@ document.addEventListener("DOMContentLoaded", function () {
 
   async function getUserObservations(username, placeId, taxonId) {
     const taxonParam = taxonId === "all" ? "" : `&taxon_id=${taxonId}`;
-    const response = await fetch(
-      `https://api.inaturalist.org/v1/observations/taxonomy?user_login=${username}&place_id=${placeId}${taxonParam}`
-    );
+    let url = `https://api.inaturalist.org/v1/observations/taxonomy?user_login=${username}&place_id=${placeId}${taxonParam}`;
+    if (wildCheckbox && wildCheckbox.checked) {
+      url = url.replace('?', '?captive=false&');
+    }
+    const response = await fetch(url);
     const data = await response.json();
 
-    return new Set(data.results.map((obs) => obs.id));
+    let allObservationIds = new Set(data.results.map((obs) => obs.id));
+
+    if (includeAllPlacesCheckbox && includeAllPlacesCheckbox.checked) {
+      let allPlacesUrl = `https://api.inaturalist.org/v1/observations/taxonomy?user_login=${username}${taxonParam}`;
+      if (wildCheckbox && wildCheckbox.checked) {
+        allPlacesUrl = allPlacesUrl.replace('?', '?captive=false&');
+      }
+      const allPlacesResponse = await fetch(allPlacesUrl);
+      const allPlacesData = await allPlacesResponse.json();
+      allPlacesData.results.forEach(obs => allObservationIds.add(obs.id));
+    }
+
+    return allObservationIds;
   }
 
   async function getTopSpecies(placeId, taxonId) {
     const taxonParam = taxonId === "all" ? "" : `&taxon_id=${taxonId}`;
     const limit = document.getElementById("limitSelect").value;
-    const response = await fetch(
-      `https://api.inaturalist.org/v1/observations/species_counts?place_id=${placeId}&per_page=${limit}${taxonParam}`
-    );
+    let url = `https://api.inaturalist.org/v1/observations/species_counts?place_id=${placeId}&per_page=${limit}${taxonParam}`;
+    if (wildCheckbox && wildCheckbox.checked) {
+      url = url.replace('?', '?captive=false&');
+    }
+    const response = await fetch(url);
     const data = await response.json();
     return data.results;
   }

--- a/script.js
+++ b/script.js
@@ -17,6 +17,8 @@ document.addEventListener("DOMContentLoaded", function () {
   const wildCheckbox = document.getElementById("wildCheckbox");
   const includeAllPlacesCheckbox = document.getElementById("includeAllPlacesCheckbox");
   const researchGradeCheckbox = document.getElementById("researchGradeCheckbox");
+  const monthDropdownButton = document.getElementById("monthDropdownButton");
+  const monthCheckboxes = document.getElementById("monthCheckboxes");
 
   // Load saved username, place ID, taxon, and limit preference from localStorage
   const savedUsername = localStorage.getItem("inatUsername");
@@ -136,6 +138,46 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   }
 
+  if (monthDropdownButton && monthCheckboxes) {
+    monthDropdownButton.addEventListener("click", function () {
+      if (monthCheckboxes.style.display === "none") {
+        monthCheckboxes.style.display = "flex";
+      } else {
+        monthCheckboxes.style.display = "none";
+      }
+    });
+  }
+
+  // Close the month dropdown if clicked outside
+  document.addEventListener("click", (e) => {
+    if (monthDropdownButton && monthCheckboxes) {
+      if (!monthDropdownButton.contains(e.target) && !monthCheckboxes.contains(e.target)) {
+        monthCheckboxes.style.display = "none";
+      }
+    }
+  });
+
+  // Save month selections to localStorage
+  if (monthCheckboxes) {
+    monthCheckboxes.querySelectorAll('input[type="checkbox"]').forEach(checkbox => {
+      checkbox.addEventListener('change', () => {
+        const selectedMonths = Array.from(monthCheckboxes.querySelectorAll('input[type="checkbox"]:checked'))
+          .map(cb => cb.value);
+        localStorage.setItem('inatMonths', JSON.stringify(selectedMonths));
+      });
+    });
+  }
+
+  // Load saved month selections
+  const savedMonths = JSON.parse(localStorage.getItem('inatMonths'));
+  if (savedMonths && monthCheckboxes) {
+    monthCheckboxes.querySelectorAll('input[type="checkbox"]').forEach(checkbox => {
+      if (savedMonths.includes(checkbox.value)) {
+        checkbox.checked = true;
+      }
+    });
+  }
+
   searchButton.addEventListener("click", async () => {
     placeId = placeIdInput.value.trim();
     console.log("Place ID: " + placeId)
@@ -182,6 +224,14 @@ document.addEventListener("DOMContentLoaded", function () {
 
   async function getUserObservations(username, placeId, taxonId) {
     const taxonParam = taxonId === "all" ? "" : `&taxon_id=${taxonId}`;
+    let monthParam = '';
+    if (monthCheckboxes) {
+      const selectedMonths = Array.from(monthCheckboxes.querySelectorAll('input[type="checkbox"]:checked'))
+        .map(cb => cb.value);
+      if (selectedMonths.length > 0) {
+        monthParam = `&month=${selectedMonths.join(',')}`;
+      }
+    }
     let url = `https://api.inaturalist.org/v1/observations/taxonomy?user_login=${username}&place_id=${placeId}${taxonParam}`;
     if (wildCheckbox && wildCheckbox.checked) {
       url = url.replace('?', '?captive=false&');
@@ -213,7 +263,15 @@ document.addEventListener("DOMContentLoaded", function () {
   async function getTopSpecies(placeId, taxonId) {
     const taxonParam = taxonId === "all" ? "" : `&taxon_id=${taxonId}`;
     const limit = document.getElementById("limitSelect").value;
-    let url = `https://api.inaturalist.org/v1/observations/species_counts?place_id=${placeId}&per_page=${limit}${taxonParam}`;
+    let monthParam = '';
+    if (monthCheckboxes) {
+      const selectedMonths = Array.from(monthCheckboxes.querySelectorAll('input[type="checkbox"]:checked'))
+        .map(cb => cb.value);
+      if (selectedMonths.length > 0) {
+        monthParam = `&month=${selectedMonths.join(',')}`;
+      }
+    }
+    let url = `https://api.inaturalist.org/v1/observations/species_counts?place_id=${placeId}&per_page=${limit}${taxonParam}${monthParam}`;
     if (wildCheckbox && wildCheckbox.checked) {
       url = url.replace('?', '?captive=false&');
     }

--- a/script.js
+++ b/script.js
@@ -159,11 +159,13 @@ document.addEventListener("DOMContentLoaded", function () {
 
   // Save month selections to localStorage
   if (monthCheckboxes) {
-    monthCheckboxes.querySelectorAll('input[type="checkbox"]').forEach(checkbox => {
+    const monthCheckboxesList = monthCheckboxes.querySelectorAll('input[type="checkbox"]');
+    monthCheckboxesList.forEach(checkbox => {
       checkbox.addEventListener('change', () => {
         const selectedMonths = Array.from(monthCheckboxes.querySelectorAll('input[type="checkbox"]:checked'))
           .map(cb => cb.value);
         localStorage.setItem('inatMonths', JSON.stringify(selectedMonths));
+        updateMonthButtonColor(); // Call new function to update button color
       });
     });
   }
@@ -176,6 +178,19 @@ document.addEventListener("DOMContentLoaded", function () {
         checkbox.checked = true;
       }
     });
+    updateMonthButtonColor(); // Call new function to set initial button color
+  }
+
+  // Function to update the month dropdown button's color
+  function updateMonthButtonColor() {
+    if (monthDropdownButton && monthCheckboxes) {
+      const anyMonthSelected = Array.from(monthCheckboxes.querySelectorAll('input[type="checkbox"]:checked')).length > 0;
+      if (anyMonthSelected) {
+        monthDropdownButton.classList.add('active-filter');
+      } else {
+        monthDropdownButton.classList.remove('active-filter');
+      }
+    }
   }
 
   searchButton.addEventListener("click", async () => {

--- a/styles.css
+++ b/styles.css
@@ -379,3 +379,62 @@ button:hover {
   color: #666;
   margin-top: 2px;
 }
+
+.research-grade-checkbox {
+  accent-color: #27ae60;
+  width: 18px;
+  height: 18px;
+}
+
+.month-filter-container {
+  position: relative;
+  display: inline-block;
+  margin-left: 24px;
+}
+
+.month-dropdown-button {
+  padding: 10px 15px;
+  background-color: #eee;
+  color: #2c3e50;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background-color 0.3s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.month-dropdown-button:hover {
+  background-color: #e1e4e8;
+}
+
+.month-checkboxes {
+  position: absolute;
+  background-color: #f9f9f9;
+  min-width: 160px;
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+  padding: 12px;
+  z-index: 1;
+  border-radius: 5px;
+  top: 100%;
+  left: 0;
+  margin-top: 5px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.month-checkboxes label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.month-checkboxes input[type="checkbox"] {
+  accent-color: #27ae60;
+  width: 16px;
+  height: 16px;
+}

--- a/styles.css
+++ b/styles.css
@@ -410,6 +410,12 @@ button:hover {
   background-color: #e1e4e8;
 }
 
+.month-dropdown-button.active-filter {
+  background-color: #27ae60;
+  color: white;
+  border-color: #27ae60;
+}
+
 .month-checkboxes {
   position: absolute;
   background-color: #f9f9f9;

--- a/styles.css
+++ b/styles.css
@@ -281,7 +281,8 @@ button:hover {
 }
 
 .advanced-options-section .wild-checkbox,
-.advanced-options-section .include-all-places-checkbox {
+.advanced-options-section .include-all-places-checkbox,
+.advanced-options-section .research-grade-checkbox {
   margin-left: 24px;
 }
 
@@ -290,7 +291,8 @@ button:hover {
 }
 
 .wild-checkbox,
-.include-all-places-checkbox {
+.include-all-places-checkbox,
+.research-grade-checkbox {
   accent-color: #27ae60;
   width: 18px;
   height: 18px;

--- a/styles.css
+++ b/styles.css
@@ -256,31 +256,78 @@ button:hover {
   }
 }
 
-.checkbox-container {
-  display: none;
+.advanced-options-section {
+  display: flex;
+  justify-content: center;
   align-items: center;
-  gap: 8px;
-  padding: 10px 15px;
-  background: white;
-  border: 2px solid #ddd;
-  border-radius: 5px;
-  cursor: pointer;
-  transition: border-color 0.3s;
+  margin: 10px 0 20px 0;
+  background: none;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  padding: 0;
+  max-width: none;
 }
 
-.checkbox-container:hover {
+#advancedOptionsButton {
+  background-color: #eee;
+  color: #2c3e50;
+  border: 1px solid #ddd;
+  margin-left: 5px;
+  transition: background 0.2s;
+}
+#advancedOptionsButton:hover {
+  background-color: #e1e4e8;
+}
+
+.advanced-options-section .wild-checkbox,
+.advanced-options-section .include-all-places-checkbox {
+  margin-left: 24px;
+}
+
+.advanced-options-section label {
+  margin-right: 10px;
+}
+
+.wild-checkbox,
+.include-all-places-checkbox {
+  accent-color: #27ae60;
+  width: 18px;
+  height: 18px;
+}
+
+.taxon-id-override-input {
+  padding: 10px 15px;
+  border: 2px solid #ddd;
+  border-radius: 5px;
+  font-size: 1rem;
+  width: 220px;
+  background-color: white;
+  margin-right: 10px;
+}
+.taxon-id-override-input:focus {
+  outline: none;
   border-color: #3498db;
+  box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+}
+
+.checkbox-container {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 20px;
+  background: #fdfdfd;
+  padding: 10px 15px;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
+  font-size: 1.05rem;
+  color: #333;
+  cursor: pointer;
+  transition: all 0.2s ease;
 }
 
 .show-missing-checkbox {
+  accent-color: #27ae60;
   width: 18px;
   height: 18px;
-  cursor: pointer;
-}
-
-.checkbox-container label {
-  cursor: pointer;
-  user-select: none;
-  color: #2c3e50;
-  font-size: 1rem;
 }


### PR DESCRIPTION
Added "Advanced Options" to Search and 2 new options to taxon dropdown (animals, vertebrates).
Advanced options changes include:
1. A "Wild Only" checkbox (excludes captive observations from the full species list when checked),
2. A "Taxon ID" box for people who want more than the default dropdown (synced to the dropdown, though, so shouldn't be confusing for users)
3. An "Include Observations From All Places" checkbox so users can see what they've observed from places outside the place of interest (e.g. I saw a cardinal in Canada, so it is counted as seen when I search inside the United States)